### PR TITLE
Changed install directory of messages and added an install step to create symbolic links.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 *~
 
 # these are left around by setup.py
-build/lib.linux-*
+build
+dist
+src/genlisp.egg-info/

--- a/cmake/genlisp-extras.cmake.in
+++ b/cmake/genlisp-extras.cmake.in
@@ -10,9 +10,7 @@ endif()
 # Generate .msg or .srv -> .lisp
 # The generated .lisp files should be added ALL_GEN_OUTPUT_FILES_lisp
 macro(_generate_lisp ARG_PKG ARG_MSG ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_DIR)
-
-  #Append msg to output dir
-  set(GEN_OUTPUT_DIR "${ARG_GEN_OUTPUT_DIR}/msg")
+  file(MAKE_DIRECTORY ${ARG_GEN_OUTPUT_DIR})
 
   #Create input and output filenames
   get_filename_component(MSG_NAME ${ARG_MSG} NAME)
@@ -38,21 +36,34 @@ endmacro()
 #genlisp uses the same program to generate srv and msg files, so call the same macro
 macro(_generate_msg_lisp ARG_PKG ARG_MSG ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_DIR)
   _generate_lisp(${ARG_PKG} ${ARG_MSG} "${ARG_IFLAGS}" "${ARG_MSG_DEPS}" "${ARG_GEN_OUTPUT_DIR}/msg")
-  install(CODE
-    "execute_process(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems
-                     COMMAND ln -s ../ros/${PROJECT_NAME}/msg/${PROJECT_NAME}-msg.asd ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems/${PROJECT_NAME}-msg.asd)")
 endmacro()
 
 #genlisp uses the same program to generate srv and msg files, so call the same macro
 macro(_generate_srv_lisp ARG_PKG ARG_SRV ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_DIR)
   _generate_lisp(${ARG_PKG} ${ARG_SRV} "${ARG_IFLAGS}" "${ARG_MSG_DEPS}" "${ARG_GEN_OUTPUT_DIR}/srv")
-  install(CODE
-    "execute_process(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems
-                     COMMAND ln -s ../ros/${PROJECT_NAME}/srv/${PROJECT_NAME}-srv.asd ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems/${PROJECT_NAME}-srv.asd)")
 endmacro()
 
-macro(_generate_module_lisp)
-  # the macros, they do nothing
+macro(_generate_module_lisp ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
+  set(GEN_ASDF_SYSTEMS_DIR ${ARG_GEN_OUTPUT_DIR}/../systems)
+  file(MAKE_DIRECTORY ${GEN_ASDF_SYSTEMS_DIR})
+
+  install(CODE
+    "file(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems)")
+  foreach(type "msg" "srv")
+    set(GEN_OUTPUT_DIR ${ARG_GEN_OUTPUT_DIR}/${type})
+    set(GEN_OUTPUT_FILE ${ARG_GEN_OUTPUT_DIR}/${type}/${ARG_PKG}-${type}.asd)
+
+    if(IS_DIRECTORY ${GEN_OUTPUT_DIR})
+      add_custom_command(OUTPUT ${GEN_OUTPUT_FILE}
+        DEPENDS ${ARG_GENERATED_FILES}
+        COMMAND ln -fs ${GEN_OUTPUT_FILE} ${GEN_ASDF_SYSTEMS_DIR}
+        COMMENT "Linking Lisp ${type} asd file for ${ARG_PKG}")
+      list(APPEND ALL_GEN_OUTPUT_FILES_lisp ${GEN_OUTPUT_FILE})
+      install(CODE
+        "execute_process(
+           COMMAND ln -s ../ros/${PROJECT_NAME}/${type}/${PROJECT_NAME}-${type}.asd ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems/${PROJECT_NAME}-${type}.asd)")
+    endif()
+  endforeach()
 endmacro()
 
 set(common_lisp_INSTALL_DIR share/common-lisp)

--- a/cmake/genlisp-extras.cmake.in
+++ b/cmake/genlisp-extras.cmake.in
@@ -38,15 +38,22 @@ endmacro()
 #genlisp uses the same program to generate srv and msg files, so call the same macro
 macro(_generate_msg_lisp ARG_PKG ARG_MSG ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_DIR)
   _generate_lisp(${ARG_PKG} ${ARG_MSG} "${ARG_IFLAGS}" "${ARG_MSG_DEPS}" "${ARG_GEN_OUTPUT_DIR}/msg")
+  install(CODE
+    "execute_process(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems
+                     COMMAND ln -s ../ros/${PROJECT_NAME}/msg/${PROJECT_NAME}-msg.asd ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems/${PROJECT_NAME}-msg.asd)")
 endmacro()
 
 #genlisp uses the same program to generate srv and msg files, so call the same macro
 macro(_generate_srv_lisp ARG_PKG ARG_SRV ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_DIR)
   _generate_lisp(${ARG_PKG} ${ARG_SRV} "${ARG_IFLAGS}" "${ARG_MSG_DEPS}" "${ARG_GEN_OUTPUT_DIR}/srv")
+  install(CODE
+    "execute_process(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems
+                     COMMAND ln -s ../ros/${PROJECT_NAME}/srv/${PROJECT_NAME}-srv.asd ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems/${PROJECT_NAME}-srv.asd)")
 endmacro()
 
 macro(_generate_module_lisp)
   # the macros, they do nothing
 endmacro()
 
-set(genlisp_INSTALL_DIR share/${PROJECT_NAME}/lisp)
+set(common_lisp_INSTALL_DIR share/common-lisp)
+set(genlisp_INSTALL_DIR ${common_lisp_INSTALL_DIR}/ros)

--- a/cmake/genlisp-extras.cmake.in
+++ b/cmake/genlisp-extras.cmake.in
@@ -44,26 +44,6 @@ macro(_generate_srv_lisp ARG_PKG ARG_SRV ARG_IFLAGS ARG_MSG_DEPS ARG_GEN_OUTPUT_
 endmacro()
 
 macro(_generate_module_lisp ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
-  set(GEN_ASDF_SYSTEMS_DIR ${ARG_GEN_OUTPUT_DIR}/../systems)
-  file(MAKE_DIRECTORY ${GEN_ASDF_SYSTEMS_DIR})
-
-  install(CODE
-    "file(MAKE_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems)")
-  foreach(type "msg" "srv")
-    set(GEN_OUTPUT_DIR ${ARG_GEN_OUTPUT_DIR}/${type})
-    set(GEN_OUTPUT_FILE ${ARG_GEN_OUTPUT_DIR}/${type}/${ARG_PKG}-${type}.asd)
-
-    if(IS_DIRECTORY ${GEN_OUTPUT_DIR})
-      add_custom_command(OUTPUT ${GEN_OUTPUT_FILE}
-        DEPENDS ${ARG_GENERATED_FILES}
-        COMMAND ln -fs ${GEN_OUTPUT_FILE} ${GEN_ASDF_SYSTEMS_DIR}
-        COMMENT "Linking Lisp ${type} asd file for ${ARG_PKG}")
-      list(APPEND ALL_GEN_OUTPUT_FILES_lisp ${GEN_OUTPUT_FILE})
-      install(CODE
-        "execute_process(
-           COMMAND ln -s ../ros/${PROJECT_NAME}/${type}/${PROJECT_NAME}-${type}.asd ${CMAKE_INSTALL_PREFIX}/${common_lisp_INSTALL_DIR}/systems/${PROJECT_NAME}-${type}.asd)")
-    endif()
-  endforeach()
 endmacro()
 
 set(common_lisp_INSTALL_DIR share/common-lisp)

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,15 @@
+<package>
+  <catkin/>
+  <description brief="genlisp">
+
+     Common-Lisp ROS message and service generators.
+
+  </description>
+  <author>Bhaskara Marti (bhaskara@willowgarage.com)</author>
+  <license>BSD</license>
+  <review status="unreviewed" notes=""/>
+  <url>http://ros.org/wiki/genlisp</url>
+
+</package>
+
+


### PR DESCRIPTION
The patches change the installation directory of roslisp messages to <prefix>/share/common-lisp/ros/<package-name>. In addition, all message and service asd files are linked to <prefix>/share/common-lisp/systems similar to the way debain's common-lisp-controller does it. Please review my cmake code :)
