### PR TITLE
Fixed duplicate search path issue

### DIFF
--- a/src/genlisp/generate.py
+++ b/src/genlisp/generate.py
@@ -734,7 +734,9 @@ def generate_srv(pkg, files, out_dir, search_path):
 def msg_list(pkg, search_path, ext):
     dir_list = search_path[pkg]
     files = []
-    for d in dir_list:
+    # Converting dir_list to a set in order to remove duplicate search paths
+    dir_set = set(dir_list)
+    for d in dir_set:
         files.extend([f for f in os.listdir(d) if f.endswith(ext)])
     return [f[:-len(ext)] for f in files]
 
@@ -745,6 +747,7 @@ def generate_msg_from_spec(msg_context, spec, search_path, output_dir, package):
     @param msg_path: The path to the .msg file
     @type msg_path: str
     """
+    
     genmsg.msg_loader.load_depends(msg_context, spec, search_path)
     spec.actual_name=spec.short_name
     spec.component_type='message'


### PR DESCRIPTION
Duplicate search paths would generate faulty .asd files form action definitions (request/feedback/reply messages get defined multiple times, i.e. breaking ASDF loading).

Fixes the problem stated on ros-users in this mail thread:
https://code.ros.org/lurker/thread/20130605.125757.7e5ce9d5.en.html
