### PR TITLE
use catkin_install_python() to install Python scripts

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
   <url type="website">http://www.ros.org/wiki/roslisp</url>
   <author email="bhaskara@willowgarage.com">Bhaskara Marti</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 
   <build_depend>genmsg</build_depend>
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -2,6 +2,6 @@ install(
   FILES msg.lisp.template srv.lisp.template
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
-install(
+catkin_install_python(
   PROGRAMS gen_lisp.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
While this is only necessary for _indigo_ it doesn't harm _groovy_ or _hydro_.
