### PR TITLE
avoid crawling share/common-lisp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,4 +13,9 @@ file(WRITE ${CATKIN_DEVEL_PREFIX}/${GENMSG_LANGS_DESTINATION}/genlisp "LISP")
 install(FILES ${CATKIN_DEVEL_PREFIX}/${GENMSG_LANGS_DESTINATION}/genlisp
   DESTINATION ${GENMSG_LANGS_DESTINATION})
 
+# drop marker file to prevent rospack from spending time on crawling this folder
+file(WRITE ${CATKIN_DEVEL_PREFIX}/share/common-lisp/rospack_nosubdirs "")
+install(FILES ${CATKIN_DEVEL_PREFIX}/share/common-lisp/rospack_nosubdirs
+  DESTINATION share/common-lisp)
+
 catkin_python_setup()


### PR DESCRIPTION
In order to avoid `rospack` crawling `share/common-lisp` this package should place a `rospack_nosubdirs` file in there.

See http://answers.ros.org/question/173322/rospack-is-too-slow/
