### PR TITLE
bug-fix: added escaping of '~' into MESSAGE-DEFINITION function code

### DIFF
--- a/src/genlisp/generate.py
+++ b/src/genlisp/generate.py
@@ -607,6 +607,7 @@ def write_message_definition(s, msg_context, spec):
             for line in lines:
                 l = line.replace('\\', '\\\\')
                 l = l.replace('"', '\\"')
+                l = l.replace('~', '~~')
                 s.write('%s~%%'%l, indent=False)
             s.write('~%', indent=False)
             s.write('"))', indent=False)


### PR DESCRIPTION
== How to test ==

Testing involves removing `build/` and `devel/`, so the smaller the workspace the better.

``` bash
$ roscd
$ cd ../src && git clone https://github.com/gaya-/weird_msg_test.git
$ cd .. && catkin_make
```

The problematic spot is the ~ here:
https://github.com/gaya-/weird_msg_test/blob/master/msg/WeirdComments.msg#L7

Close Emacs, open Emacs (or reinitialize rosdep registry of your rosemacs)

```
CL-USER> ,r-l-s
weird_msg_test
weird-msg-test
```

I prefer `ros-load-system` here because it gives a better error report.

Observe the error.

---

Fetch the pull request.
Remove `build/` and `devel/` (maybe only `devel/`or maybe simply `catkin_make --force-cmake`).
Compile.

```
CL-USER> ,restart-inferior-lisp
CL-USER> (asdf:load-system :weird-msg-test)
```

Error fixed.
