### PR TITLE
Added support for string constants

### DIFF
--- a/src/genlisp/generate.py
+++ b/src/genlisp/generate.py
@@ -674,7 +674,16 @@ def write_constants(s, spec):
                 s.write('\'(')
                 with Indent(s, indent_first=False):
                     for c in spec.constants:
-                        s.write('(:%s . %s)'%(c.name.upper(), c.val))
+                        if c.type == 'string':
+                            if '"' in c.val:
+                                # crude escaping of \ and "
+                                escaped = c.val.replace('\\', '\\\\')
+                                escaped = escaped.replace('\"', '\\"')
+                                s.write('(:%s . "%s")'%(c.name.upper(), escaped))
+                            else:
+                                s.write('(:%s . "%s")'%(c.name.upper(), c.val))
+                        else:
+                            s.write('(:%s . %s)'%(c.name.upper(), c.val))
             s.write(')', False)
             s.write(')')
 


### PR DESCRIPTION
Given a message file such as:

```
string EMPTY=
string SOME_NORMAL_STRING=Blabla
string SOME_STRING_WITH_QUOTES="Hello"
string STRING_WITH_SINGLE_QUOTES='there'
string STRING_WITH_BACKSLASH=bla\bla
uint8 NORMAL_CONSTANT=0

string type
```

the Python autogenerated class would have the constants look as following:
```python
  # Pseudo-constants
  EMPTY = ''
  SOME_NORMAL_STRING = 'Blabla'
  SOME_STRING_WITH_QUOTES = r'"Hello"'
  STRING_WITH_SINGLE_QUOTES = r"'there'"
  STRING_WITH_BACKSLASH = 'bla\bla'
  NORMAL_CONSTANT = 0
```

and the Lisp autogenerated message file would look as following:
```lisp
(cl:defmethod roslisp-msg-protocol:symbol-codes ((msg-type (cl:eql '<Test>)))
    "Constants for message type '<Test>"
  '((:EMPTY . )
    (:SOME_NORMAL_STRING . Blabla)
    (:SOME_STRING_WITH_QUOTES . "Hello")
    (:STRING_WITH_SINGLE_QUOTES . 'there')
    (:STRING_WITH_BACKSLASH . bla\bla)
    (:NORMAL_CONSTANT . 0))
)
```

which has incorrect Lisp syntax and does not compile in Lisp.
With this PR the generated message looks as following, which seems fine:

```lisp
(cl:defmethod roslisp-msg-protocol:symbol-codes ((msg-type (cl:eql 'Test)))
    "Constants for message type 'Test"
  '((:EMPTY . "")
    (:SOME_NORMAL_STRING . "Blabla")
    (:SOME_STRING_WITH_QUOTES . "\"Hello\"")
    (:STRING_WITH_SINGLE_QUOTES . "'there'")
    (:STRING_WITH_BACKSLASH . "bla\bla")
    (:NORMAL_CONSTANT . 0))
)
```

The test message I used for testing can be found here:
https://github.com/gaya-/test_msgs