### PR TITLE
Make setup.py not executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 


### PR DESCRIPTION
The `setup.py` file is used by `catkin_python_setup()`, and [isn't meant to be executed directly](http://docs.ros.org/melodic/api/catkin/html/user_guide/setup_dot_py.html). This removes the shebang and executable permissions from the file.