### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,8 @@
   <author email="bhaskara@willowgarage.com">Bhaskara Marti</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_depend>genmsg</build_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model
+  href="http://download.ros.org/schema/package_format3.xsd"
+  schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>genlisp</name>
   <version>0.4.17</version>
   <description>
@@ -16,7 +19,7 @@
 
   <build_depend>genmsg</build_depend>
 
-  <run_depend>genmsg</run_depend>
+  <exec_depend>genmsg</exec_depend>
 
   <export>
     <message_generator>lisp</message_generator>

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
On Debian Buster and Ubuntu Focal [distutils has been split to a separate package](https://packages.debian.org/buster/python3-setuptools). With https://github.com/ros/catkin/pull/1048 catkin will prefer to use `setuptools` instead of `distutils`. This PR switches to `setuptools` to match catkin's preference. It uses conditional dependencies so it still works when `ROS_PYTHON_VERSION` is 2 to enable the target branch to be released to earlier ROS distros than Noetic.